### PR TITLE
postgresql docker image upgrade 11.5 to 11.6-alpine

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   database:
-    image: postgres:11.5
+    image: postgres:11.6-alpine
     environment:
       - POSTGRES_USER=codimd
       - POSTGRES_PASSWORD=change_password


### PR DESCRIPTION
## About This

PostgreSQL docker image has been raised from 11.5 to 11.6.

Also, the size is dramatically reduced by changing the base image to alpine.

## Images

### Before

[Image Layer Details - postgres:11.5 - sha256:e49ebd64ed6c0035aa5ee8626ff4d697800305f518da3c364ce9e9c306892c8b - Docker Hub](https://hub.docker.com/layers/postgres/library/postgres/11.5/images/sha256-e49ebd64ed6c0035aa5ee8626ff4d697800305f518da3c364ce9e9c306892c8b)

### After

[Image Layer Details - postgres:11.6-alpine - sha256:f239499a66c151b93b79e8df0b3ca4b57704f4f9e66ff7e70ef60f5a4bb54753 - Docker Hub](https://hub.docker.com/layers/postgres/library/postgres/11.6-alpine/images/sha256-f239499a66c151b93b79e8df0b3ca4b57704f4f9e66ff7e70ef60f5a4bb54753)

## Compatibility

If it is a minor update of 11.x system, it has been confirmed that it works normally because it is compatible.

Execute `docker-compose down` while using version 11.5.
Then change to `11.6-alpine` Run with `docker-compose up -d`
Confirmed that the same data can be used.

11.5 to 11.6
11.6 to 11.5
There is no problem if it is a minor version.

![image](https://user-images.githubusercontent.com/19791597/72429292-f3bb0000-37d2-11ea-869f-f92111410b4f.png)


Thank you,